### PR TITLE
Make push-logic-frame-with work with nonlocal exits and multiple values

### DIFF
--- a/src/ui.lisp
+++ b/src/ui.lisp
@@ -203,10 +203,10 @@
 
   "
   (once-only (database)
-    `(prog2
-      (push-logic-frame ,database)
-      (progn ,@body)
-      (finalize-logic-frame ,database))))
+    `(unwind-protect (progn
+                       (push-logic-frame ,database)
+                       ,@body)
+       (finalize-logic-frame ,database))))
 
 
 ;;;; Querying -----------------------------------------------------------------


### PR DESCRIPTION
If the body returns out of the block the logic frame will not be finalized. This change also supports multiple return values from the body.